### PR TITLE
Allow Kue configuration

### DIFF
--- a/lib/kue-cleanup.js
+++ b/lib/kue-cleanup.js
@@ -20,7 +20,7 @@ var kue = require('kue'),
 
             instance.config = config || {};
 
-            jobs = kue.createQueue();
+            jobs = kue.createQueue(instance.config);
 
             instance.setupJobs(instance.config);
         },
@@ -183,12 +183,10 @@ function queueIterator (ids, queueFilterChain, queueActionChain, callback) {
  * @param  {Function} callback callback
  */
 function performCleanup (callback) {
-  var ki = new kue();
-  KueCleanup.ki = ki;
-  clearState('failed', ki, function(){
-    clearState('active', ki, function(){
-      clearState('complete', ki, function(){
-        clearState('inactive', ki, function(){
+  clearState('failed', jobs, function(){
+    clearState('active', jobs, function(){
+      clearState('complete', jobs, function(){
+        clearState('inactive', jobs, function(){
           callback();
         });
       });


### PR DESCRIPTION
The creation of a new Kue instance is done without passing any
configuration options, which makes impossible for the developer to
customize the created queue (for example: use unix socket instead of
a TCP/IP connection). Furthermore, Kueue uses a singleton for the queue,
so, creating a KueCleanup instance before any other invocation to
"createQueue" could result in Kue ignoring any configuration parameters
that the developer assumed that where going to take effect when
making those invocations.

Add a "config" parameter to the KueCleanup constructor that is passed
to the createQueue method, in order to configure the queue that is
created.
